### PR TITLE
Change `Mos6502JsSafe` to use address map accessor methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,12 +75,14 @@ impl From<Mos6502> for Mos6502JsSafe {
         ram.iter_mut()
             .enumerate()
             .map(|(offset, byte)| (offset as u16, byte))
-            .for_each(|(offset, byte)| *byte = src.address_map.read(offset));
+            .for_each(|(offset, byte)| *byte = src.with_address_map(|am| am.read(offset)));
+
         let mut rom = [0u8; ROM_SIZE];
+        let rom_base_addr = 0x8000u16;
         rom.iter_mut()
             .enumerate()
-            .map(|(offset, byte)| ((offset as u16 + 0x8000u16), byte))
-            .for_each(|(offset, byte)| *byte = src.address_map.read(offset));
+            .map(|(offset, byte)| ((offset as u16 + rom_base_addr), byte))
+            .for_each(|(offset, byte)| *byte = src.with_address_map(|am| am.read(offset)));
 
         Self {
             ram: ram,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,17 +72,16 @@ impl Mos6502JsSafe {
 impl From<Mos6502> for Mos6502JsSafe {
     fn from(src: Mos6502) -> Self {
         let mut ram = [0u8; RAM_SIZE];
-        ram.iter_mut()
-            .enumerate()
-            .map(|(offset, byte)| (offset as u16, byte))
-            .for_each(|(offset, byte)| *byte = src.with_address_map(|am| am.read(offset)));
+        for (offset, byte) in ram.iter_mut().enumerate() {
+            *byte = src.with_address_map(|am| am.read(offset as u16));
+        }
 
         let mut rom = [0u8; ROM_SIZE];
         let rom_base_addr = 0x8000u16;
-        rom.iter_mut()
-            .enumerate()
-            .map(|(offset, byte)| ((offset as u16 + rom_base_addr), byte))
-            .for_each(|(offset, byte)| *byte = src.with_address_map(|am| am.read(offset)));
+        for (idx, byte) in rom.iter_mut().enumerate() {
+            let offset = idx as u16 + rom_base_addr;
+            *byte = src.with_address_map(|am| am.read(offset));
+        }
 
         Self {
             ram: ram,


### PR DESCRIPTION
# Introduction
This is a small PR to change the `Mos6502JsSafe` type to use address map accessor methods rather than modifying directly on the public interface. Honestly, this is a cosmetic change more than anything else.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
