### PR TITLE
Update dependencies to reflect branch changes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.3/containers/rust/.devcontainer/base.Dockerfile
 
-FROM mcr.microsoft.com/vscode/devcontainers/base:stretch
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 
 ENV NVM_VERSION="v0.38.0"
 ENV USERNAME="vscode"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ opt-level = "s"
 [dependencies]
 wasm-bindgen = "0.2"
 mainspring = { git = "https://github.com/ncatelli/mainspring", branch = "main" }
-spasm = { git = "https://github.com/ncatelli/spasm", branch = "master" }
-scrap = { git = "https://github.com/ncatelli/scrap", branch = "main" }
+spasm = { git = "https://github.com/ncatelli/spasm", branch = "main" }
+scrap = { git = "https://github.com/ncatelli/scrap", tag = "v1.0.0" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ cargo build --release
 
 ### Browser
 ```
+npm install
 wasm-pack build
 cd www/
 npm run start

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,17 +48,22 @@ fn main() -> Result<(), String> {
     let help_string = cmd.help();
     cmd.evaluate(&args[..])
         .map_err(|e| RuntimeError::Undefined(e.to_string()).to_string())
-        .and_then(|(flags, help)| {
-            if help.is_none() {
-                cmd.dispatch((flags, help))
-                    // On success print the state
-                    .map(|cpu| println!("{:#?}", cpu))
-                    // On failure, format an error.
-                    .map_err(|e| format!("{}\n\n{}", &e.to_string(), &help_string))
-            } else {
-                println!("{:?}", &help_string);
-                Ok(())
-            }
-        })
+        .and_then(
+            |scrap::Value {
+                 value: (flags, help),
+                 span,
+             }| {
+                if help.is_none() {
+                    cmd.dispatch(scrap::Value::new(span, (flags, help)))
+                        // On success print the state
+                        .map(|cpu| println!("{:#?}", cpu))
+                        // On failure, format an error.
+                        .map_err(|e| format!("{}\n\n{}", &e.to_string(), &help_string))
+                } else {
+                    println!("{:?}", &help_string);
+                    Ok(())
+                }
+            },
+        )
         .map_err(|e| e.to_string())
 }

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1,16 +1,13 @@
 {
-  "name": "create-wasm-app",
+  "name": "bes",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "create-wasm-app",
+      "name": "bes",
       "version": "0.1.0",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "create-wasm-app": ".bin/create-wasm-app.js"
-      },
+      "license": "Apache-2.0",
       "devDependencies": {
         "bes": "file:../pkg",
         "copy-webpack-plugin": "^5.0.0",
@@ -20,6 +17,7 @@
       }
     },
     "../pkg": {
+      "name": "bes",
       "version": "0.1.0",
       "dev": true
     },


### PR DESCRIPTION
# Introduction
This PR fixes the change of spasm from a `master` to a `main` default branch. Additionally this pins scrap to the v1.0.0 release.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
